### PR TITLE
Resolve Google OAuth 'refresh_token' issue in Keycloak Integration

### DIFF
--- a/src/core/adapters/oidc/oidc.ts
+++ b/src/core/adapters/oidc/oidc.ts
@@ -64,9 +64,9 @@ export async function createOidc(params: {
         // See: https://stackoverflow.com/questions/10827920/not-receiving-google-oauth-refresh-token/10857806#10857806
         // Without a Google refresh Keycloak is unable to refresh the Google access token during token exchange.
         // The prompt value "consent" is not yet supported by 'keycloak js'. In the meantime, we have to use @ts-ignore.
-        // @ts-ignore
         await keycloakInstance.login({
             "redirectUri": window.location.href,
+            // @ts-ignore
             "prompt": "consent"
         });
 

--- a/src/core/adapters/oidc/oidc.ts
+++ b/src/core/adapters/oidc/oidc.ts
@@ -60,8 +60,15 @@ export async function createOidc(params: {
         if (doesCurrentHrefRequiresAuth) {
             redirectMethod = "location.replace";
         }
-
-        await keycloakInstance.login({ "redirectUri": window.location.href });
+        // A Google `refresh_token` is only provided during the initial user authorization process, unless prompt is set to consent.
+        // See: https://stackoverflow.com/questions/10827920/not-receiving-google-oauth-refresh-token/10857806#10857806
+        // Without a Google refresh Keycloak is unable to refresh the Google access token during token exchange.
+        // The prompt value "consent" is not yet supported by 'keycloak js'. In the meantime, we have to use @ts-ignore.
+        // @ts-ignore
+        await keycloakInstance.login({
+            "redirectUri": window.location.href,
+            "prompt": "consent"
+        });
 
         return new Promise<never>(() => {});
     };

--- a/src/core/adapters/oidc/oidc.ts
+++ b/src/core/adapters/oidc/oidc.ts
@@ -62,7 +62,7 @@ export async function createOidc(params: {
         }
         // A Google `refresh_token` is only provided during the initial user authorization process, unless prompt is set to consent.
         // See: https://stackoverflow.com/questions/10827920/not-receiving-google-oauth-refresh-token/10857806#10857806
-        // Without a Google refresh Keycloak is unable to refresh the Google access token during token exchange.
+        // Without a Google refresh token, Keycloak is unable to refresh the Google access token during token exchange.
         // The prompt value "consent" is not yet supported by 'keycloak js'. In the meantime, we have to use @ts-ignore.
         await keycloakInstance.login({
             "redirectUri": window.location.href,


### PR DESCRIPTION
### Description
Google OAuth only provides a refresh_token during the initial user authorization process, unless a specific parameter, "prompt," is set to "consent." However, the 'keycloak js' library use by Onxyia-web, does not support the "prompt" value "consent," which is necessary to ensure that we obtain a refresh_token from Google.  After this change, Keycloak will be able to refresh Google access token during token exchange. 

The use of '@ts-ignore' serves as a temporary workaround until the 'keycloak js' library adds support for the 'prompt' value 'consent'.

### References

- [Same issue described in statisticsnorway/jupyterhub-extensions](https://github.com/statisticsnorway/jupyterhub-extensions/blob/e47dbb813e13d063adf38dd4ffcf1b299a8d7b82/TokenExchangeAuthenticator/README.md?plain=1#L48C1-L48C76)
- [Stack overflow thread describing the google refresh_token issue](https://stackoverflow.com/questions/10827920/not-receiving-google-oauth-refresh-token/10857806#10857806)

