### PR TITLE
Disable the command bar by default

### DIFF
--- a/web/.env
+++ b/web/.env
@@ -197,7 +197,7 @@ REACT_APP_DISABLE_PERSONAL_INFOS_INJECTION_IN_GROUP=false
 # To hide the command bar by default, 
 # it can be enabled back in the account page by the user.  
 # For reference this is the command bar: https://github.com/InseeFrLab/onyxia/assets/6702424/474da82c-a0e1-4107-acf7-84870aab9f78
-REACT_APP_DISABLE_COMMAND_BAR=false
+REACT_APP_DISABLE_COMMAND_BAR=true
 
 
 # ===== Devlevel params ======


### PR DESCRIPTION
Most of SSB's end users doesn't use helm, so this PR will hide the command bar by default. 